### PR TITLE
CFPQ-by-tensor fixes

### DIFF
--- a/project/cfpq/tensor.py
+++ b/project/cfpq/tensor.py
@@ -41,7 +41,7 @@ def constrained_transitive_closure_by_tensor(
         # Iterate over non-empty indices
         for i, j in transitive_closure_indices:
             # Translate intersection indices into RSM decomposition indices
-            r_i, r_j = i // len(rsm_decomp.states), j // len(rsm_decomp.states)
+            r_i, r_j = i // len(graph_decomp.states), j // len(graph_decomp.states)
             # If the edge is from a start RSM node to a final RSM node
             s, f = rsm_decomp.states[r_i], rsm_decomp.states[r_j]
             if s.is_start and f.is_final:
@@ -50,7 +50,7 @@ def constrained_transitive_closure_by_tensor(
                 v = s.data[0]
 
                 # Translate intersection indices into graph decomposition indices
-                g_i, g_j = i % len(rsm_decomp.states), j % len(rsm_decomp.states)
+                g_i, g_j = i % len(graph_decomp.states), j % len(graph_decomp.states)
                 # Cannot directly update CSR arrays element-wise
                 ij_graph_adj = csr_array(
                     ([True], ([g_i], [g_j])),

--- a/tests/data/test_cfpq_transitive_closures.json
+++ b/tests/data/test_cfpq_transitive_closures.json
@@ -43,7 +43,7 @@
       ]
     },
     {
-      "description": "two cycles graphF",
+      "description": "two cycles graph",
       "graph": "digraph {0 [is_start=True, is_final=True]; 1 [is_start=True, is_final=True]; 2 [is_start=True, is_final=True]; 3 [is_start=True, is_final=True]; 0 -> 1 [label=a]; 1 -> 2 [label=a]; 2 -> 0 [label=a]; 2 -> 3 [label=b]; 3 -> 2 [label=b]}",
       "cfg": "S -> A B | A S1\nS1 -> S B\nA -> a\nB -> b",
       "expected": [

--- a/tests/test_cfpq_transitive_closures.py
+++ b/tests/test_cfpq_transitive_closures.py
@@ -4,6 +4,7 @@ from pyformlang import cfg as c
 
 from project.cfpq.hellings import constrained_transitive_closure_by_hellings
 from project.cfpq.matrix import constrained_transitive_closure_by_matrix
+from project.cfpq.tensor import constrained_transitive_closure_by_tensor
 from testing_utils import load_test_data
 from testing_utils import load_test_ids
 from testing_utils import dot_str_to_graph
@@ -32,5 +33,10 @@ class TestCfpqConstrainedTransitiveClosures:
 
     def test_matrix(self, graph: nx.Graph, cfg: c.CFG, expected: set[tuple]):
         actual = constrained_transitive_closure_by_matrix(graph, cfg)
+
+        assert actual == expected
+
+    def test_tensor(self, graph: nx.Graph, cfg: c.CFG, expected: set[tuple]):
+        actual = constrained_transitive_closure_by_tensor(graph, cfg)
 
         assert actual == expected


### PR DESCRIPTION
- Adds missing tests for `constrained_transitive_closure_by_tensor`
- Fixes indices translation in `constrained_transitive_closure_by_tensor` (revealed by the added tests)